### PR TITLE
Don't hide failure in CI when pushing image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,6 @@ script:
       docker build . -t "${IMAGE}"
       IMAGESLIST+=("${IMAGE}")
     done
-
-after_success:
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - |
     for IMAGE in "${IMAGESLIST[@]}"


### PR DESCRIPTION
`after_success` failure [doesn't fail build](https://travis-ci.org/github/florianbelhomme/docker-symfony/jobs/673391043#L1619-L1630)

As result [7.4-buster-apache isn't available](https://hub.docker.com/r/solune/symfony/tags?page=1&name=7.4-buster-apache).